### PR TITLE
Fixes for adapting in serial PR

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -102,7 +102,7 @@ class RiemannianMetric(ffunc.Function):
         # Adjust the section
         entity_dofs = np.zeros(tdim + 1, dtype=np.int32)
         entity_dofs[0] = tdim**2
-        plex.setSection(mesh.create_section(entity_dofs))
+        plex.setSection(mesh.create_section(entity_dofs)[0])
 
         # Process spatially variable metric parameters
         self._variable_parameters = {
@@ -263,7 +263,7 @@ class RiemannianMetric(ffunc.Function):
         """
         entity_dofs = np.zeros(self._tdim + 1, dtype=np.int32)
         entity_dofs[0] = self._mesh.geometric_dimension()
-        coord_section = self._mesh.create_section(entity_dofs)
+        coord_section = self._mesh.create_section(entity_dofs)[0]
         # NOTE: section doesn't have any fields, but PETSc assumes it to have one
         coord_dm = self._plex.getCoordinateDM()
         coord_dm.setSection(coord_section)

--- a/animate/utility.py
+++ b/animate/utility.py
@@ -2,7 +2,6 @@
 Utility functions and classes for metric-based mesh adaptation.
 """
 
-import os
 from collections import OrderedDict
 
 import firedrake
@@ -11,7 +10,7 @@ import ufl
 from firedrake.__future__ import interpolate
 from firedrake.petsc import PETSc
 
-__all__ = ["Mesh", "VTKFile", "norm", "errornorm", "get_checkpoint_dir"]
+__all__ = ["Mesh", "VTKFile", "norm", "errornorm"]
 
 
 @PETSc.Log.EventDecorator()
@@ -299,20 +298,3 @@ def function2cofunction(func):
     else:
         cofunc.dat.data_with_halos[:] = func.dat.data_with_halos
     return cofunc
-
-
-def get_checkpoint_dir():
-    """
-    Retrieve the path to Animate's checkpoint directory.
-    """
-    if os.environ.get("ANIMATE_CHECKPOINT_DIR"):
-        checkpoint_dir = os.environ["ANIMATE_CHECKPOINT_DIR"]
-    else:
-        import animate
-
-        assert os.path.basename(animate.__file__) == "__init__.py"
-        animate_base_dir = os.path.dirname(animate.__file__)
-        checkpoint_dir = os.path.join(animate_base_dir, ".checkpoints")
-    if not os.path.exists(checkpoint_dir):
-        os.makedirs(checkpoint_dir, exist_ok=True)
-    return checkpoint_dir

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -22,20 +22,6 @@ class TestCheckpointing(unittest.TestCase):
         checkpoint_dir = get_checkpoint_dir()
         self.assertTrue(os.path.exists(checkpoint_dir))
 
-    # def test_filepath_error(self):
-    #     with self.assertRaises(ValueError) as cm:
-    #         _fix_checkpoint_filename("path/to/file")
-    #     error_message = str(cm.exception)
-    #     msg = "Provide a filename, not a filepath. Checkpoints will be stored in '"
-    #     self.assertTrue(error_message.startswith(msg))
-    #     self.assertTrue(get_checkpoint_dir() in error_message)
-
-    # def test_extension_error(self):
-    #     with self.assertRaises(ValueError) as cm:
-    #         _fix_checkpoint_filename("checkpoint.wrong")
-    #     msg = "File extension '.wrong' not recognised. Use '.h5'."
-    #     self.assertEqual(str(cm.exception), msg)
-
     def test_file_created(self):
         filename = "test_file_created.h5"
         chk_dir = get_checkpoint_dir()

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -70,6 +70,13 @@ class TestCheckpointing(unittest.TestCase):
         self.assertFalse(os.path.exists(fpath))
         self.assertTrue(np.allclose(self.metric.dat.data, self.loaded_metric.dat.data))
 
+    def test_load_notexist_error(self):
+        fpath = os.path.join(self.checkpoint_dir, "nonexistant.h5")
+        with self.assertRaises(Exception) as cm:
+            load_checkpoint(fpath, "mesh", "metric")
+        msg = f"Metric file does not exist! Path: {fpath}."
+        self.assertEqual(str(cm.exception), msg)
+
     def test_load_custom_mesh_name(self):
         custom_mesh_name = "custom_mesh_name"
         custom_mesh = uniform_mesh(2, 1, name=custom_mesh_name)

--- a/test/test_utility.py
+++ b/test/test_utility.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 from test_setup import *
 from test_setup import uniform_mesh
 
-from animate.utility import assemble_mass_matrix, get_checkpoint_dir
+from animate.utility import assemble_mass_matrix
 
 pointwise_norm_types = [["l1"], ["l2"], ["linf"]]
 integral_scalar_norm_types = [["L1"], ["L2"], ["L4"], ["H1"], ["HCurl"]]
@@ -236,16 +236,6 @@ class TestErrorNorm(unittest.TestCase):
         condition = conditional(And(self.x < 0.5, self.y < 0.5), 1.0, 0.0)
         val = errornorm(self.f, self.g, norm_type=norm_type, condition=condition)
         self.assertAlmostEqual(val, expected)
-
-
-class TestGetCheckpointDir(unittest.TestCase):
-    """
-    Unit tests for :func:`get_checkpoint_dir`.
-    """
-
-    def test_exists(self):
-        checkpoint_dir = get_checkpoint_dir()
-        self.assertTrue(os.path.exists(checkpoint_dir))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Here are some changes that I think address all issues raised in the original PR #72:
- I am creating the checkpoint dir using `tempfile.mkdtemp`, as suggested in [this comment](https://github.com/mesh-adaptation/animate/pull/72#discussion_r1523844000)
- Instead of the checkpoint file name, `save_checkpoint` and `load_checkpoint` now take the checkpoint file path as an argument. The main reason for this is to tidy up the code since I don't really see a benefit of doing it the other way around. I also think it was confusing. But I'm happy to revert this!
- I moved `get_checkpoint_dir` from `utility.py` to `checkpointing.py`. I'm not sure why we'd have checkpointing-related things outside of `checkpointing.py`? :)
- Added a test for attempting to load a checkpoint file that doesn't exist