### PR TITLE
Mass lumping: vector fields

### DIFF
--- a/animate/interpolation.py
+++ b/animate/interpolation.py
@@ -109,10 +109,7 @@ def _supermesh_project(source, target, bounded=False):
         element_s = Vs.ufl_element()
         Vs_sub = firedrake.FunctionSpace(s_mesh, element_s.family(), element_s.degree())
         Vt_sub = firedrake.FunctionSpace(t_mesh, element_t.family(), element_t.degree())
-        # source_sub = ffunc.Function(Vs_sub).assign(source.sub(i))
-        source_sub = ffunc.Function(Vs_sub)
-        ss = source.sub(i)
-        source_sub.assign(ss)  # this is where the error is raised
+        source_sub = ffunc.Function(Vs_sub).assign(source.sub(i))
         target_sub = ffunc.Function(Vt_sub)
 
         # Create a linear system using the lumped mass matrix for the target space
@@ -133,8 +130,8 @@ def _supermesh_project(source, target, bounded=False):
         maximum = ufl.max_value(proj, interp)
         q_dev = ffunc.Function(Vt_sub)
         q_alt = ffunc.Function(Vt_sub)
-        maxiter = 10_000
-        atol = 1.0e-05
+        maxiter = 100_000
+        atol = 1.0e-07
         Mt = assemble_mass_matrix(Vt_sub, lumped=False)
         for j in range(maxiter):
             q_dev.interpolate(


### PR DESCRIPTION
Hi @jwallwork23, I have been trying again to get this to work for vector fields and I think I got it. I hope I won't sound rude when I ask this: could I please ask you if you could take a look into this, instead of prioritising https://github.com/mesh-adaptation/goalie/issues/188 as you said you would? Lumping really did make a significant difference in my case, whereas the adjoint action issue is (I assume, but could very easily be wrong) not so significant. So I'd really like to get this sorted out :) and I hope this will be pretty straightforward.

I basically just put what you did here inside a `for` loop, but I had to create `FunctionSpace`s for individual components in a messy way, since just doing `source.sub(i).function_space()` didn't work. Anyway, the ping pong demo results (i.e. scalar fields) are identical, and I tested it on a vector field and it looks good.

I also tried it out on the `burgers.py` demo, by passing `transfer_kwargs={"bounded": True}` to `MeshSeq` and then got this (tolerance of 1e-7). In doing that, I also had to do `pyadjoint.pause_annotation()` inside `solve_forward` before transferring the checkpoint to the next subinterval (and then I continued annotating after the transfer). Otherwise the `assign` in `source_sub = ffunc.Function(Vs_sub).assign(source.sub(i))` raises an error.

![image](https://github.com/mesh-adaptation/animate/assets/33790330/78518536-7fd4-4756-bf0a-ca780ca27c53)