### PR TITLE
Enable C linting rules

### DIFF
--- a/animate/interpolation.py
+++ b/animate/interpolation.py
@@ -326,15 +326,15 @@ def clement_interpolant(source, target_space=None, boundary=False):
     # Process target space
     Vt = target_space
     if Vt is None:
-        if rank == 0:
-            Vt = firedrake.FunctionSpace(mesh, "CG", 1)
-        elif rank == 1:
-            Vt = firedrake.VectorFunctionSpace(mesh, "CG", 1)
-        else:
-            Vt = firedrake.TensorFunctionSpace(mesh, "CG", 1)
+        Vt_ranks = {
+            0: firedrake.FunctionSpace(mesh, "CG", 1),
+            1: firedrake.VectorFunctionSpace(mesh, "CG", 1),
+            2: firedrake.TensorFunctionSpace(mesh, "CG", 1),
+        }
+        Vt = Vt_ranks[rank]
     elif isinstance(Vt, FiredrakeDualSpace):
         Vt = Vt.dual()
-    elif not isinstance(Vt, FiredrakeDualSpace):
+    else:
         is_cofunction = False
     Vt_e = Vt.ufl_element()
     if not (Vt_e.family() == "Lagrange" and Vt_e.degree() == 1):
@@ -346,14 +346,12 @@ def clement_interpolant(source, target_space=None, boundary=False):
     P1 = firedrake.FunctionSpace(mesh, "CG", 1)
 
     # Determine target domain
-    if rank == 0:
-        tdomain = "{[i]: 0 <= i < t.dofs}"
-    elif rank == 1:
-        tdomain = f"{{[i, j]: 0 <= i < t.dofs and 0 <= j < {dim}}}"
-    else:
-        tdomain = (
-            f"{{[i, j, k]: 0 <= i < t.dofs and 0 <= j < {dim} and 0 <= k < {dim}}}"
-        )
+    tdomain_ranks = {
+        0: "{[i]: 0 <= i < t.dofs}",
+        1: f"{{[i, j]: 0 <= i < t.dofs and 0 <= j < {dim}}}",
+        2: f"{{[i, j, k]: 0 <= i < t.dofs and 0 <= j < {dim} and 0 <= k < {dim}}}",
+    }
+    tdomain = tdomain_ranks[rank]
 
     # Compute the patch volume at each vertex
     if not boundary:
@@ -368,12 +366,12 @@ def clement_interpolant(source, target_space=None, boundary=False):
         firedrake.par_loop((domain, instructions), dX, keys)
 
         # Take weighted average
-        if rank == 0:
-            instructions = "t[i] = t[i] + v[0] * s[0]"
-        elif rank == 1:
-            instructions = "t[i, j] = t[i, j] + v[0] * s[0, j]"
-        else:
-            instructions = f"t[i, {dim} * j + k] = t[i, {dim} * j + k] + v[0] * s[0, {dim} * j + k]"
+        instructions_ranks = {
+            0: "t[i] = t[i] + v[0] * s[0]",
+            1: "t[i, j] = t[i, j] + v[0] * s[0, j]",
+            2: f"t[i, {dim} * j + k] = t[i, {dim} * j + k] + v[0] * s[0, {dim} * j + k]",
+        }
+        instructions = instructions_ranks[rank]
         keys = {
             "s": (source, op2.READ),
             "v": (volume, op2.READ),
@@ -408,12 +406,12 @@ def clement_interpolant(source, target_space=None, boundary=False):
         firedrake.par_loop((domain, instructions), dX, keys)
 
         # Take weighted average
-        if rank == 0:
-            instructions = "t[i] = t[i] + v[0] * b[i] * s[0]"
-        elif rank == 1:
-            instructions = "t[i, j] = t[i, j] + v[0] * b[i] * s[0, j]"
-        else:
-            instructions = f"t[i, {dim} * j + k] = t[i, {dim} * j + k] + v[0] * b[i] * s[0, {dim} * j + k]"
+        instructions_ranks = {
+            0: "t[i] = t[i] + v[0] * b[i] * s[0]",
+            1: "t[i, j] = t[i, j] + v[0] * b[i] * s[0, j]",
+            2: f"t[i, {dim} * j + k] = t[i, {dim} * j + k] + v[0] * b[i] * s[0, {dim} * j + k]",
+        }
+        instructions = instructions_ranks[rank]
         keys = {
             "s": (source, op2.READ),
             "v": (bnd_volume, op2.READ),

--- a/animate/interpolation.py
+++ b/animate/interpolation.py
@@ -326,12 +326,11 @@ def clement_interpolant(source, target_space=None, boundary=False):
     # Process target space
     Vt = target_space
     if Vt is None:
-        Vt_ranks = {
-            0: firedrake.FunctionSpace(mesh, "CG", 1),
-            1: firedrake.VectorFunctionSpace(mesh, "CG", 1),
-            2: firedrake.TensorFunctionSpace(mesh, "CG", 1),
-        }
-        Vt = Vt_ranks[rank]
+        Vt = {
+            0: firedrake.FunctionSpace,
+            1: firedrake.VectorFunctionSpace,
+            2: firedrake.TensorFunctionSpace,
+        }[rank](mesh, "CG", 1)
     elif isinstance(Vt, FiredrakeDualSpace):
         Vt = Vt.dual()
     else:
@@ -346,12 +345,11 @@ def clement_interpolant(source, target_space=None, boundary=False):
     P1 = firedrake.FunctionSpace(mesh, "CG", 1)
 
     # Determine target domain
-    tdomain_ranks = {
+    tdomain = {
         0: "{[i]: 0 <= i < t.dofs}",
         1: f"{{[i, j]: 0 <= i < t.dofs and 0 <= j < {dim}}}",
         2: f"{{[i, j, k]: 0 <= i < t.dofs and 0 <= j < {dim} and 0 <= k < {dim}}}",
-    }
-    tdomain = tdomain_ranks[rank]
+    }[rank]
 
     # Compute the patch volume at each vertex
     if not boundary:
@@ -366,12 +364,11 @@ def clement_interpolant(source, target_space=None, boundary=False):
         firedrake.par_loop((domain, instructions), dX, keys)
 
         # Take weighted average
-        instructions_ranks = {
+        instructions = {
             0: "t[i] = t[i] + v[0] * s[0]",
             1: "t[i, j] = t[i, j] + v[0] * s[0, j]",
             2: f"t[i, {dim} * j + k] = t[i, {dim} * j + k] + v[0] * s[0, {dim} * j + k]",
-        }
-        instructions = instructions_ranks[rank]
+        }[rank]
         keys = {
             "s": (source, op2.READ),
             "v": (volume, op2.READ),
@@ -406,12 +403,11 @@ def clement_interpolant(source, target_space=None, boundary=False):
         firedrake.par_loop((domain, instructions), dX, keys)
 
         # Take weighted average
-        instructions_ranks = {
+        instructions = {
             0: "t[i] = t[i] + v[0] * b[i] * s[0]",
             1: "t[i, j] = t[i, j] + v[0] * b[i] * s[0, j]",
             2: f"t[i, {dim} * j + k] = t[i, {dim} * j + k] + v[0] * b[i] * s[0, {dim} * j + k]",
-        }
-        instructions = instructions_ranks[rank]
+        }[rank]
         keys = {
             "s": (source, op2.READ),
             "v": (bnd_volume, op2.READ),

--- a/animate/quality.py
+++ b/animate/quality.py
@@ -88,7 +88,7 @@ class QualityMeasure:
         with open(self.fname, "r") as f:
             code = f.read()
         func = firedrake.Function(self.P0, name=name)
-        kwargs = dict(cpp=True, include_dirs=include_dir)
+        kwargs = {"cpp": True, "include_dirs": include_dir}
         kernel = op2.Kernel(code, f"get_{name}", **kwargs)
         op2.par_loop(kernel, self.mesh.cell_set, *self._get_dats(func))
         return func

--- a/animate/utility.py
+++ b/animate/utility.py
@@ -154,12 +154,12 @@ def norm(v, norm_type="L2", condition=None, boundary=False):
                 raise ValueError(f"'{norm_type}' norm does not make sense.")
             integrand = ufl.inner(v, v)
         elif norm_type.lower() in ("h1", "hdiv", "hcurl"):
-            integrands_dict = {
-                "h1": ufl.inner(v, v) + ufl.inner(ufl.grad(v), ufl.grad(v)),
-                "hdiv": ufl.inner(v, v) + ufl.div(v) * ufl.div(v),
-                "hcurl": ufl.inner(v, v) + ufl.inner(ufl.curl(v), ufl.curl(v)),
-            }
-            integrand = integrands_dict[norm_type.lower()]
+            integrand = {
+                "h1": lambda w: ufl.inner(w, w) + ufl.inner(ufl.grad(w), ufl.grad(w)),
+                "hdiv": lambda w: ufl.inner(w, w) + ufl.div(w) * ufl.div(w),
+                "hcurl": lambda w: ufl.inner(w, w)
+                + ufl.inner(ufl.curl(w), ufl.curl(w)),
+            }[norm_type.lower()](v)
         else:
             raise ValueError(f"Unknown norm type '{norm_type}'.")
         return firedrake.assemble(condition * integrand ** (p / 2) * dX) ** (1 / p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ select = [
   "I",  # isort
 ]
 ignore = [
-  "C901",  # function too complex (TODO #108: enable this)
   "E501",  # line too long
   "E226",  # missing whitespace around arithmetic operator
   "E402",  # module level import not at top of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,13 @@ line-length = 88
 [tool.ruff.lint]
 select = [
   "B",  # flake8-bugbear
-#  "C",  # mccabe complexity  TODO: enable this (#108)
+  "C",  # mccabe complexity
   "E", "W",  # Pycodestyle
   "F",  # Pyflakes
   "I",  # isort
 ]
 ignore = [
+  "C901",  # function too complex (TODO #108: enable this)
   "E501",  # line too long
   "E226",  # missing whitespace around arithmetic operator
   "E402",  # module level import not at top of file


### PR DESCRIPTION
Closes #108.

After #120, the remaining linting errors are:
```
animate/interpolation.py:296:5: C901 `clement_interpolant` is too complex (19 > 10)
animate/quality.py:91:18: C408 Unnecessary `dict` call (rewrite as a literal)
animate/utility.py:97:5: C901 `norm` is too complex (13 > 10)
animate/utility.py:169:5: C901 `errornorm` is too complex (12 > 10)
```

This PR addresses all of them apart from the final one, to which I added `noqa: C901`. The complexity mostly comes from the `if isinstance` checks so I don't think it's that bad to begin with. And I guess I could replace those with `assert` but I would rather not do that. @jwallwork23 do you see a nice way to simplify it please? :)

