### PR TITLE
Truncate infinite degree when passing to PETSc

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,7 +25,7 @@ jobs:
     name: 'Test suite'
     runs-on: ubuntu-latest
     container:
-      image: jwallwork/firedrake-parmmg:latest
+      image: ghcr.io/mesh-adaptation/firedrake-parmmg:latest
       options: --user root
     steps:
       - uses: actions/checkout@v2

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -229,9 +229,8 @@ class RiemannianMetric(ffunc.Function):
         self._variable_parameters.update(vp)
 
         mp = self._metric_parameters.copy()
-        if "dm_plex_metric_p" in mp:
-            if mp["dm_plex_metric_p"] == np.inf:
-                mp["dm_plex_metric_p"] = 1.79769e308
+        if mp.get("dm_plex_metric_p") == np.inf:
+            mp["dm_plex_metric_p"] = 1.79769e308
 
         # Pass parameters to PETSc
         with OptionsManager(mp, "").inserted_options():

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -228,8 +228,13 @@ class RiemannianMetric(ffunc.Function):
         self._metric_parameters.update(mp)
         self._variable_parameters.update(vp)
 
+        mp = self._metric_parameters.copy()
+        if "dm_plex_metric_p" in mp:
+            if mp["dm_plex_metric_p"] == np.inf:
+                mp["dm_plex_metric_p"] = 1.79769e308
+
         # Pass parameters to PETSc
-        with OptionsManager(self._metric_parameters, "").inserted_options():
+        with OptionsManager(mp, "").inserted_options():
             self._plex.metricSetFromOptions()
         if self._plex.metricIsUniform():
             raise NotImplementedError(

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -60,8 +60,8 @@ def test_adapt_2dparallel_error():
 
 @pytest.mark.parametrize(
     "dim,serialise",
-    [(2, True)],  # [(2, True), (3, True), (3, False)], # FIXME: hang (#136)
-    ids=["mmg2d"],  # ["mmg2d", "mmg3d, ParMmg"],
+    [(2, True), (3, True), (3, False)],
+    ids=["mmg2d", "mmg3d", "ParMmg"],
 )
 def test_no_adapt(dim, serialise):
     """


### PR DESCRIPTION
Closes #141.

It seems PETSc no longer likes being passed `np.inf`. Note that we aren't actually using PETSc's metric normalisation funcationality anyway so this isn't a big deal.