### PR TITLE
Updates due to Firedrake's new installation process

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,4 +25,4 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@fix_reusable_test_workflow
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@main

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -29,4 +29,3 @@ jobs:
     with:
       test-command: |
         export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints
-        mpiexec -n 3 --use-hwthread-cpus python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[3] test

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@main
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@fix_reusable_test_workflow
     with:
       test-command: |
         export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -29,3 +29,4 @@ jobs:
     with:
       test-command: |
         export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints
+        mpiexec -n 3 --use-hwthread-cpus python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[3] test

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@main
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@112_pip_install
     with:
       test-command: |
         export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@112_pip_install
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@main
     with:
       test-command: |
         export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -26,6 +26,3 @@ on:
 jobs:
   test_suite:
     uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@116_zizmor
-    with:
-      test-command: |
-        export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,4 +25,4 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@116_zizmor
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@fix_reusable_test_workflow

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@fix_reusable_test_workflow
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@116_zizmor
     with:
       test-command: |
         export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint:
 # `mpiexec -n N ... parallel[N]` only runs tests with @pytest.mark.parallel(nprocs=N)
 test: lint
 	@echo "Running all tests..."
-	@python3 -m pytest -v --durations=20 -k "not parallel" test
+	@python3 -m pytest -v --durations=20 -k "parallel[1] or not parallel" test
 	@mpiexec -n 2 python3 -m pytest -v -m parallel[2] test
 	@mpiexec -n 3 python3 -m pytest -v -m parallel[3] test
 	@echo "Done."
@@ -31,7 +31,7 @@ test: lint
 coverage:
 	@echo "Generating coverage report..."
 	@python3 -m coverage erase
-	@python3 -m coverage run --parallel-mode --source=animate -m pytest -v -k "not parallel" test
+	@python3 -m coverage run --parallel-mode --source=animate -m pytest -v -k "parallel[1] or not parallel" test
 	@mpiexec -n 2 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[2] test
 	@mpiexec -n 3 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[3] test
 	@python3 -m coverage combine

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,17 @@ lint:
 
 test: lint
 	@echo "Running all tests..."
-	@python3 -m pytest -v --durations=20 test
+	@python3 -m pytest -v --durations=20 -k "not parallel" test
+	@mpiexec -n 2 python3 -m pytest -v -m parallel[2] test
+	@mpiexec -n 3 python3 -m pytest -v -m parallel[3] test
 	@echo "Done."
 
 coverage:
 	@echo "Generating coverage report..."
 	@python3 -m coverage erase
-	@python3 -m coverage run --source=animate -m pytest -v test
+	@python3 -m coverage run --source=animate -m pytest -v -k "not parallel" test
+	@mpiexec -n 2 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[2] test
+	@mpiexec -n 3 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[3] test
 	@python3 -m coverage html
 	@echo "Done."
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ lint:
 	@ruff check
 	@echo "PASS"
 
+# `mpiexec -n N ... parallel[N]` only runs tests with @pytest.mark.parallel(nprocs=N)
 test: lint
 	@echo "Running all tests..."
 	@python3 -m pytest -v --durations=20 -k "not parallel" test
@@ -30,9 +31,11 @@ test: lint
 coverage:
 	@echo "Generating coverage report..."
 	@python3 -m coverage erase
-	@python3 -m coverage run --source=animate -m pytest -v -k "not parallel" test
+	@python3 -m coverage run --parallel-mode --source=animate -m pytest -v -k "not parallel" test
 	@mpiexec -n 2 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[2] test
 	@mpiexec -n 3 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[3] test
+	@python3 -m coverage combine
+	@python3 -m coverage report -m
 	@python3 -m coverage html
 	@echo "Done."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "cffconvert",
+  "coverage",
   "parameterized",
   "pre-commit",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
   "Programming Language :: Python",
 ]
 dependencies = [
-  "sympy"
+  "sympy",
+  "matplotlib",
+  "vtk",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
   "sympy",
-  "matplotlib",
   "vtk",
 ]
 

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -3,7 +3,7 @@ Unit tests for invoking mesh adaptation tools Mmg2d, Mmg3d, and ParMmg.
 """
 
 import importlib.util
-from pathlib import Path
+import os
 
 import numpy as np
 import pytest
@@ -28,9 +28,9 @@ def load_mesh(fname):
     :rtype: :class:`firedrake.mesh.MeshGeometry`
     """
     firedrake_spec = importlib.util.find_spec("firedrake")
-    firedrake_basedir = Path(firedrake_spec.origin).parent.parent
-    mesh_dir = firedrake_basedir / "tests" / "firedrake" / "meshes"
-    return Mesh(str(mesh_dir / f"{fname}.msh"))
+    firedrake_basedir = os.path.dirname(os.path.dirname(firedrake_spec.origin))
+    mesh_dir = os.path.join(firedrake_basedir, "tests", "firedrake", "meshes")
+    return Mesh(os.path.join(mesh_dir, fname + ".msh"))
 
 
 def try_adapt(mesh, metric, serialise=None):

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -2,7 +2,8 @@
 Unit tests for invoking mesh adaptation tools Mmg2d, Mmg3d, and ParMmg.
 """
 
-import os
+import importlib.util
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -26,9 +27,10 @@ def load_mesh(fname):
     :return: the mesh
     :rtype: :class:`firedrake.mesh.MeshGeometry`
     """
-    venv = os.environ.get("VIRTUAL_ENV")
-    mesh_dir = os.path.join(venv, "src", "firedrake", "tests", "firedrake", "meshes")
-    return Mesh(os.path.join(mesh_dir, fname + ".msh"))
+    firedrake_spec = importlib.util.find_spec("firedrake")
+    firedrake_basedir = Path(firedrake_spec.origin).parent.parent
+    mesh_dir = firedrake_basedir / "tests" / "firedrake" / "meshes"
+    return Mesh(str(mesh_dir / f"{fname}.msh"))
 
 
 def try_adapt(mesh, metric, serialise=None):

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -92,7 +92,8 @@ def test_no_adapt(dim, serialise):
 
 @pytest.mark.parallel(nprocs=2)
 @pytest.mark.parametrize(
-    "dim,serialise", [(3, True), (3, False)], ids=["mmg3d", "ParMmg"]
+    # "dim,serialise", [(3, True), (3, False)], ids=["mmg3d", "ParMmg"]  # Hangs (#136)
+    "dim,serialise", [(3, True),], ids=["mmg3d",]
 )
 def test_no_adapt_parallel(dim, serialise):
     """


### PR DESCRIPTION
Related to https://github.com/mesh-adaptation/docs/pull/114.

Sadly we now get another hanging parallel test: `test_no_adapt_parallel[Parmmg]`. I decided to remove it for now and will comment on #136 if you agree.

Edit: Parallel tests with 3 processes works (see comments below).

~~It seems like we can't run parallel tests with more than 2 processes anymore in the CI. Perhaps there's a good way to do it (ubuntu runners should support up to 4), but this isn't really a problem for us since we only have one tests with `nprocs = 3` (see comment below). I saw in https://github.com/thetisproject/thetis/pull/392 that they also don't do it; i.e., they set~~
```
    env:
      # Make sure that tests with >2 processes are not silently skipped
      PYTEST_MPI_MAX_NPROCS: 2
```
~~in their workflow. This causes the CI to fail, though. So I didn't want to include that in our workflow since, again, we only have one such test.~~