### PR TITLE
Add missing matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools"]
+requires = [
+  "matplotlib",
+  "setuptools",
+]
 
 [project]
 name = "animate"


### PR DESCRIPTION
Regular Animate CI is failing
https://github.com/mesh-adaptation/animate/actions/runs/13743684239/job/38435966261

Looks like we're missing a `matplotlib` dependency as well.