### PR TITLE
Fix failure to import with prefix-installed petsc

### DIFF
--- a/animate/quality.py
+++ b/animate/quality.py
@@ -11,8 +11,8 @@ from firedrake.petsc import PETSc
 from pyop2 import op2
 from pyop2.utils import get_petsc_dir
 
-PETSC_DIR, PETSC_ARCH = get_petsc_dir()
-include_dir = ["%s/include/eigen3" % PETSC_ARCH]
+petsc_dirs = get_petsc_dir()
+include_dir = ["%s/include/eigen3" % petsc_dirs[-1]]
 
 __all__ = ["QualityMeasure"]
 


### PR DESCRIPTION
Closes #174.

Rationale: for a local petsc build, get_petsc_dir() returns two directories: 1) $PETSC_DIR 2) $PETSC_DIR/$PETSC_ARCH. For prefix installed petsc where PETSC_ARCH is not set, it only returns one directory, namely $PETSC_DIR. For the purpose of finding the eigen header files we always want to use the last of the directories returned by get_petsc_dir().