### PR TITLE
Implement restrict_anisotropy_first

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -75,7 +75,6 @@ class RiemannianMetric(ffunc.Function):
         if isinstance(function_space, fmesh.MeshGeometry):
             function_space = ffs.TensorFunctionSpace(function_space, "CG", 1)
         self._metric_parameters = {}
-        self._restrict_anisotropy_first = False
         metric_parameters = kwargs.pop("metric_parameters", {})
         super().__init__(function_space, *args, **kwargs)
 
@@ -228,7 +227,7 @@ class RiemannianMetric(ffunc.Function):
         * `isotropic`: Optimisation for isotropic metrics. (Currently unsupported.)
         * `uniform`: Optimisation for uniform metrics. (Currently unsupported.)
         * `restrict_anisotropy_first`: Boolean flag specifying that anisotropy should be
-            restricted before normalisation when True. Default: False.
+            restricted before normalisation when True. Default: True.
 
         :kwarg metric_parameters: parameters as above
         :type metric_parameters: :class:`dict` with :class:`str` keys and value which
@@ -241,10 +240,11 @@ class RiemannianMetric(ffunc.Function):
         # handle the `dm_plex_metric_restrict_anisotropy_first` option here rather than
         # delegating it to PETSc (which has its own normalisation implementation).
         if "dm_plex_metric_restrict_anisotropy_first" in mp:
-            self._restrict_anisotropy_first = True
-            mp.pop("dm_plex_metric_restrict_anisotropy_first")
+            self._restrict_anisotropy_first = mp.pop(
+                "dm_plex_metric_restrict_anisotropy_first"
+            )
         else:
-            self._restrict_anisotropy_first = False
+            self._restrict_anisotropy_first = True
 
         # Stash the metric parameters on the RiemannianMetric
         self._metric_parameters.update(mp)

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -10,6 +10,7 @@ from firedrake.functionspace import (
     TensorFunctionSpace,
     VectorFunctionSpace,
 )
+from firedrake.mesh import Mesh
 from firedrake.norms import errornorm, norm
 from parameterized import parameterized
 from sensors import bowl, hyperbolic, interweaved, multiscale
@@ -153,21 +154,14 @@ class TestSetParameters(MetricTestCase):
         metric = uniform_metric(uniform_mesh(2))
         with self.assertRaises(NotImplementedError) as cm:
             metric.set_parameters({"dm_plex_metric_uniform": None})
-        msg = "Uniform metric optimisations are not supported in Firedrake."
+        msg = "Uniform metric optimisations are not supported in Animate."
         self.assertEqual(str(cm.exception), msg)
 
     def test_isotropic_notimplemented_error(self):
         metric = uniform_metric(uniform_mesh(2))
         with self.assertRaises(NotImplementedError) as cm:
             metric.set_parameters({"dm_plex_metric_isotropic": None})
-        msg = "Isotropic metric optimisations are not supported in Firedrake."
-        self.assertEqual(str(cm.exception), msg)
-
-    def test_restrict_anisotropy_first_notimplemented_error(self):
-        metric = uniform_metric(uniform_mesh(2))
-        with self.assertRaises(NotImplementedError) as cm:
-            metric.set_parameters({"dm_plex_metric_restrict_anisotropy_first": None})
-        msg = "Restricting metric anisotropy first is not supported in Firedrake."
+        msg = "Isotropic metric optimisations are not supported in Animate."
         self.assertEqual(str(cm.exception), msg)
 
     def test_p_valueerror(self):

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -378,6 +378,7 @@ class TestNormalisation(MetricTestCase):
             "dm_plex_metric_h_max": 0.2,
             "dm_plex_metric_a_max": 10,
             "dm_plex_metric_target_complexity": 1000,
+            "dm_plex_metric_restrict_anisotropy_first": False,
         }
         indefinite_matrix = ufl.as_matrix([[100, 0], [0, 0]])
 
@@ -392,7 +393,7 @@ class TestNormalisation(MetricTestCase):
         # Verify that switching the order fixes things
         metric2 = RiemannianMetric(P1_ten)
         metric2.interpolate(indefinite_matrix)
-        mp["dm_plex_metric_restrict_anisotropy_first"] = None
+        mp["dm_plex_metric_restrict_anisotropy_first"] = True
         metric2.set_parameters(mp)
         metric2.normalise()
         self.assertAlmostEqual(metric2.complexity(), 1000)

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -10,7 +10,6 @@ from firedrake.functionspace import (
     TensorFunctionSpace,
     VectorFunctionSpace,
 )
-from firedrake.mesh import Mesh
 from firedrake.norms import errornorm, norm
 from parameterized import parameterized
 from sensors import bowl, hyperbolic, interweaved, multiscale

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -370,7 +370,11 @@ class TestNormalisation(MetricTestCase):
         msg = "Normalisation on the boundary not yet implemented."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_restrict_anisotropy_first(self):
+    def test_restrict_anisotropy_first_false(self):
+        """
+        Verify that normalising before restricting anisotropy is problematic for an
+        indefinite matrix.
+        """
         mesh = uniform_mesh(2, n=10)
         P1_ten = TensorFunctionSpace(mesh, "CG", 1)
         mp = {
@@ -380,23 +384,29 @@ class TestNormalisation(MetricTestCase):
             "dm_plex_metric_target_complexity": 1000,
             "dm_plex_metric_restrict_anisotropy_first": False,
         }
-        indefinite_matrix = ufl.as_matrix([[100, 0], [0, 0]])
+        metric = RiemannianMetric(P1_ten, metric_parameters=mp)
+        metric.interpolate(ufl.as_matrix([[100, 0], [0, 0]]))
+        metric.normalise()
+        self.assertGreater(metric.complexity(), 1e8)
 
-        # Verify that normalising before restricting anisotropy is problematic for an
-        # indefinite matrix
-        metric1 = RiemannianMetric(P1_ten)
-        metric1.interpolate(indefinite_matrix)
-        metric1.set_parameters(mp)
-        metric1.normalise()
-        self.assertAlmostEqual(metric1.complexity(), 1e9, places=5)
-
-        # Verify that switching the order fixes things
-        metric2 = RiemannianMetric(P1_ten)
-        metric2.interpolate(indefinite_matrix)
-        mp["dm_plex_metric_restrict_anisotropy_first"] = True
-        metric2.set_parameters(mp)
-        metric2.normalise()
-        self.assertAlmostEqual(metric2.complexity(), 1000)
+    def test_restrict_anisotropy_first_true(self):
+        """
+        Verify that restricting aniosotropy first allows us to attain the target metric
+        complexity in the case of an indefinite matrix.
+        """
+        mesh = uniform_mesh(2, n=10)
+        P1_ten = TensorFunctionSpace(mesh, "CG", 1)
+        mp = {
+            "dm_plex_metric_h_min": 1e-5,
+            "dm_plex_metric_h_max": 0.2,
+            "dm_plex_metric_a_max": 10,
+            "dm_plex_metric_target_complexity": 1000,
+            "dm_plex_metric_restrict_anisotropy_first": True,
+        }
+        metric = RiemannianMetric(P1_ten, metric_parameters=mp)
+        metric.interpolate(ufl.as_matrix([[100, 0], [0, 0]]))
+        metric.normalise()
+        self.assertAlmostEqual(metric.complexity(), 1000)
 
 
 class TestMetricDrivers(MetricTestCase):


### PR DESCRIPTION
Closes #100.
Closes #178

Allows the user to restrict anisotropy before normalising the metric. I couldn't think of a useful test for this functionality. Any thoughts?