### PR TITLE
Provide links to metric-based docs sections

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -529,6 +529,10 @@ class RiemannianMetric(ffunc.Function):
         """
         Apply :math:`L^p` normalisation to the metric.
 
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#metric-normalisation
+        for more details.
+
         :kwarg global_factor: pre-computed global normalisation factor
         :type global_factor: :class:`float`
         :kwarg boundary: is the normalisation to be done over the boundary?

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -580,6 +580,10 @@ class RiemannianMetric(ffunc.Function):
         Metric intersection means taking the minimal ellipsoid in the direction of each
         eigenvector at each point in the domain.
 
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#combining-metrics
+        for more details.
+
         :arg metrics: the metrics to be intersected with
         :type metrics: :class:`tuple` of :class:`~.RiemannianMetric`\s
         :return: the intersected metric, modified in-place
@@ -650,6 +654,10 @@ class RiemannianMetric(ffunc.Function):
     def combine(self, *metrics, average=True, **kwargs):
         r"""
         Combine metrics using either averaging or intersection.
+
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#combining-metrics
+        for more details.
 
         :arg metrics: the list of metrics to combine with
         :type metrics: :class:`tuple` of :class:`~.RiemannianMetric`\s

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -803,6 +803,10 @@ class RiemannianMetric(ffunc.Function):
 
         where :math:`h_i := \frac1{\sqrt{\lambda_i}}`.
 
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#geometric-interpretation
+        for more details.
+
         :kwarg reorder: should the eigendecomposition be reordered?
         :type reorder: :class:`bool`
         :return: metric density, anisotropy quotients and eigenvector matrix represented

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -699,6 +699,10 @@ class RiemannianMetric(ffunc.Function):
         r"""
         Compute the eigenvectors and eigenvalues of a matrix-valued function.
 
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#geometric-interpretation
+        for more information.
+
         :kwarg reorder: should the eigendecomposition be reordered in order of
             *descending* eigenvalue magnitude?
         :type reorder: :class:`bool`
@@ -730,6 +734,10 @@ class RiemannianMetric(ffunc.Function):
     def assemble_eigendecomposition(self, evectors, evalues):
         """
         Assemble a matrix from its eigenvectors and eigenvalues.
+
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#geometric-interpretation
+        for more information.
 
         :arg evectors: eigenvectors represented as a matrix-valued function
         :type evectors: :class:`firedrake.function.Function`

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -680,6 +680,10 @@ class RiemannianMetric(ffunc.Function):
         Compute the metric complexity - the continuous analogue
         of the (inherently discrete) mesh vertex count.
 
+        See
+        https://mesh-adaptation.github.io/animate/1-metric-based.html#continuous-mesh-analogy
+        for more details.
+
         :kwarg boundary: should the complexity be computed over the domain boundary?
         :type boundary: :class:`bool`
         :return: the complexity of the metric

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -530,7 +530,7 @@ class RiemannianMetric(ffunc.Function):
         Apply :math:`L^p` normalisation to the metric.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#metric-normalisation
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#metric-normalisation
         for more details.
 
         :kwarg global_factor: pre-computed global normalisation factor
@@ -585,7 +585,7 @@ class RiemannianMetric(ffunc.Function):
         eigenvector at each point in the domain.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#combining-metrics
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#combining-metrics
         for more details.
 
         :arg metrics: the metrics to be intersected with
@@ -660,7 +660,7 @@ class RiemannianMetric(ffunc.Function):
         Combine metrics using either averaging or intersection.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#combining-metrics
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#combining-metrics
         for more details.
 
         :arg metrics: the list of metrics to combine with
@@ -681,7 +681,7 @@ class RiemannianMetric(ffunc.Function):
         of the (inherently discrete) mesh vertex count.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#continuous-mesh-analogy
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#continuous-mesh-analogy
         for more details.
 
         :kwarg boundary: should the complexity be computed over the domain boundary?
@@ -700,7 +700,7 @@ class RiemannianMetric(ffunc.Function):
         Compute the eigenvectors and eigenvalues of a matrix-valued function.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#geometric-interpretation
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#geometric-interpretation
         for more information.
 
         :kwarg reorder: should the eigendecomposition be reordered in order of
@@ -736,7 +736,7 @@ class RiemannianMetric(ffunc.Function):
         Assemble a matrix from its eigenvectors and eigenvalues.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#geometric-interpretation
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#geometric-interpretation
         for more information.
 
         :arg evectors: eigenvectors represented as a matrix-valued function
@@ -816,7 +816,7 @@ class RiemannianMetric(ffunc.Function):
         where :math:`h_i := \frac1{\sqrt{\lambda_i}}`.
 
         See
-        https://mesh-adaptation.github.io/animate/1-metric-based.html#geometric-interpretation
+        https://mesh-adaptation.github.io/docs/animate/1-metric-based.html#geometric-interpretation
         for more details.
 
         :kwarg reorder: should the eigendecomposition be reordered?


### PR DESCRIPTION
Closes #32.

Linked PR: https://github.com/mesh-adaptation/docs/pull/143.