### PR TITLE
Fix import of OptionsManager for firedrake release

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -9,8 +9,13 @@ import sympy
 import ufl
 from firedrake.__future__ import interpolate
 from firedrake.petsc import PETSc
-from petsctools import OptionsManager
 from pyop2 import op2
+
+try:
+    # only works in firedrake release <=2025.4.x
+    from firedrake.petsc import OptionsManager
+except ImportError:
+    from petsctools import OptionsManager
 
 from .interpolation import clement_interpolant
 from .recovery import (


### PR DESCRIPTION
Fixes #196

The fix to import OptionsManager from petsctools, which is needed in firedrake master, appears to break with the current firedrake release version because petsctools needs to be initialized (which is done by firedrake) - also release doesn't depend on petsctools so the package isn't installed automatically.

Attempt to import OptionsManager directly from firedrake first - which should work in release - and if not import it from petsctools.