### PR TITLE
Avoid use of `.vector()`

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -496,13 +496,13 @@ class RiemannianMetric(ffunc.Function):
         a_max = interp(self._variable_parameters["dm_plex_metric_a_max"])
 
         # Check minimal h_min value is positive and smaller than minimal h_max value
-        _hmin = h_min.vector().gather().min()
+        _hmin = h_min.dat.global_data.min()
         if _hmin <= 0.0:
             raise ValueError(f"Encountered non-positive h_min value: {_hmin}.")
-        if h_max.vector().gather().min() < _hmin:
+        if h_max.dat.global_data.min() < _hmin:
             raise ValueError(
                 "Minimum h_max value is smaller than minimum h_min value:"
-                f"{h_max.vector().gather().min()} < {_hmin}."
+                f"{h_max.dat.global_data.min()} < {_hmin}."
             )
 
         # Check h_max is always at least h_min
@@ -512,7 +512,7 @@ class RiemannianMetric(ffunc.Function):
             raise ValueError("Encountered regions where h_max < h_min.")
 
         # Check minimal a_max value is close to unity or larger
-        _a_max = a_max.vector().gather().min()
+        _a_max = a_max.dat.global_data.min()
         if not np.isclose(_a_max, 1.0) and _a_max < 1.0:
             raise ValueError(f"Encountered a_max value smaller than unity: {_a_max}.")
 
@@ -934,7 +934,7 @@ class RiemannianMetric(ffunc.Function):
         )
 
     def _any_inf(self, f):
-        arr = f.vector().gather()
+        arr = f.dat.global_data
         return np.isinf(arr).any() or np.isnan(arr).any()
 
     @PETSc.Log.EventDecorator()
@@ -1002,7 +1002,7 @@ class RiemannianMetric(ffunc.Function):
         P0 = firedrake.FunctionSpace(mesh, "DG", 0)
         K_opt = pow(error_indicator, 1 / (convergence_rate + 1))
         K_opt_av = (
-            K_opt / firedrake.assemble(interpolate(K_opt, P0)).vector().gather().sum()
+            K_opt / firedrake.assemble(interpolate(K_opt, P0)).dat.global_data.sum()
         )
         K_ratio = target_complexity * pow(abs(K_opt_av * K_hat / K), 2 / dim)
 

--- a/animate/recovery.py
+++ b/animate/recovery.py
@@ -152,7 +152,7 @@ def recover_boundary_hessian(f, method="Clement", target_space=None, **kwargs):
     h = firedrake.assemble(
         interpolate(ufl.CellDiameter(mesh), firedrake.FunctionSpace(mesh, "DG", 0))
     )
-    h = firedrake.Constant(1 / h.vector().gather().max() ** 2)
+    h = firedrake.Constant(1 / h.dat.global_data.max() ** 2)
     sp = {
         "ksp_type": "gmres",
         "ksp_gmres_restart": 20,

--- a/demos/ping_pong.py
+++ b/demos/ping_pong.py
@@ -64,8 +64,8 @@ plt.savefig("ping_pong-source_function.jpg", bbox_inches="tight")
 
 niter = 50
 initial_integral = assemble(source * dx)
-initial_min = source.vector().gather().min()
-initial_max = source.vector().gather().max()
+initial_min = source.dat.global_data.min()
+initial_max = source.dat.global_data.max()
 quantities = {
     "integral": {"interpolate": [initial_integral]},
     "minimum": {"interpolate": [initial_min]},
@@ -77,8 +77,8 @@ for _ in range(niter):
     interpolate(f_interp, tmp)
     interpolate(tmp, f_interp)
     quantities["integral"]["interpolate"].append(assemble(f_interp * dx))
-    quantities["minimum"]["interpolate"].append(f_interp.vector().gather().min())
-    quantities["maximum"]["interpolate"].append(f_interp.vector().gather().max())
+    quantities["minimum"]["interpolate"].append(f_interp.dat.global_data.min())
+    quantities["maximum"]["interpolate"].append(f_interp.dat.global_data.max())
 f_interp.rename("Interpolate")
 
 fig, axes = plt.subplots(ncols=3, figsize=(18, 5))
@@ -139,8 +139,8 @@ for _ in range(niter):
     project(f_proj, tmp)
     project(tmp, f_proj)
     quantities["integral"]["project"].append(assemble(f_proj * dx))
-    quantities["minimum"]["project"].append(f_proj.vector().gather().min())
-    quantities["maximum"]["project"].append(f_proj.vector().gather().max())
+    quantities["minimum"]["project"].append(f_proj.dat.global_data.min())
+    quantities["maximum"]["project"].append(f_proj.dat.global_data.max())
 f_proj.rename("Project")
 
 fig, axes = plt.subplots(ncols=3, figsize=(18, 5))
@@ -189,8 +189,8 @@ for _ in range(niter):
     project(f_bounded, tmp, bounded=True)
     project(tmp, f_bounded, bounded=True)
     quantities["integral"]["bounded"].append(assemble(f_bounded * dx))
-    quantities["minimum"]["bounded"].append(f_bounded.vector().gather().min())
-    quantities["maximum"]["bounded"].append(f_bounded.vector().gather().max())
+    quantities["minimum"]["bounded"].append(f_bounded.dat.global_data.min())
+    quantities["maximum"]["bounded"].append(f_bounded.dat.global_data.max())
 f_bounded.rename("Bounded project")
 
 fig, axes = plt.subplots(ncols=3, figsize=(18, 5))

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -158,8 +158,10 @@ def test_preserve_facet_tags_2d(meshname):
 
 @pytest.mark.parametrize(
     "dim,serialise",
-    [(2, True), (3, True)],
-    ids=["mmg2d", "mmg3d"],
+    # [(2, True), (3, True)],  # FIXME: Broken test (#197)
+    [(2, True)],
+    # ids=["mmg2d", "mmg3d"],  # FIXME: Broken test (#197)
+    ids=["mmg2d"],
 )
 def test_adapt(dim, serialise):
     """

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -144,7 +144,6 @@ def test_preserve_facet_tags_2d(meshname):
     metric = uniform_metric(mesh)
     newmesh = try_adapt(mesh, metric)
 
-    newmesh.init()
     tags = set(mesh.exterior_facets.unique_markers)
     newtags = set(newmesh.exterior_facets.unique_markers)
     assert tags == newtags, "Facet tags do not match"

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -76,7 +76,7 @@ def test_no_adapt(dim, serialise):
     Ensure mesh adaptation operations can be turned off.
     """
     mesh = uniform_mesh(dim)
-    dofs = mesh.coordinates.vector().gather().shape
+    dofs = mesh.coordinates.dat.global_data.shape
     mp = {
         "dm_plex_metric": {
             "no_insert": None,
@@ -87,13 +87,19 @@ def test_no_adapt(dim, serialise):
     }
     metric = uniform_metric(mesh, metric_parameters=mp)
     newmesh = try_adapt(mesh, metric, serialise=serialise)
-    assert newmesh.coordinates.vector().gather().shape == dofs
+    assert newmesh.coordinates.dat.global_data.shape == dofs
 
 
 @pytest.mark.parallel(nprocs=2)
 @pytest.mark.parametrize(
     # "dim,serialise", [(3, True), (3, False)], ids=["mmg3d", "ParMmg"]  # Hangs (#136)
-    "dim,serialise", [(3, True),], ids=["mmg3d",]
+    "dim,serialise",
+    [
+        (3, True),
+    ],
+    ids=[
+        "mmg3d",
+    ],
 )
 def test_no_adapt_parallel(dim, serialise):
     """
@@ -160,7 +166,7 @@ def test_adapt(dim, serialise):
     Test that we can successfully invoke Mmg and that it changes the DoF count.
     """
     mesh = uniform_mesh(dim)
-    dofs = mesh.coordinates.vector().gather().shape
+    dofs = mesh.coordinates.dat.global_data.shape
     mp = {
         "dm_plex_metric": {
             "target_complexity": 100.0,
@@ -169,7 +175,7 @@ def test_adapt(dim, serialise):
     }
     metric = uniform_metric(mesh, metric_parameters=mp)
     newmesh = try_adapt(mesh, metric, serialise=serialise)
-    assert newmesh.coordinates.vector().gather().shape != dofs
+    assert newmesh.coordinates.dat.global_data.shape != dofs
 
 
 @pytest.mark.parallel(nprocs=2)
@@ -191,7 +197,7 @@ def test_adapt_parallel_np2(dim, serialise):
 @pytest.mark.parametrize(
     "dim,serialise",
     [(2, True), (3, True)],  # [(2, True), (3, True), (3, False)], # FIXME: hang (#136)
-    ids=["mmg2d", "mmg3d"], # ["mmg2d", "mmg3d", "ParMmg"],
+    ids=["mmg2d", "mmg3d"],  # ["mmg2d", "mmg3d", "ParMmg"],
 )
 def test_adapt_parallel_np3(dim, serialise):
     """
@@ -212,11 +218,11 @@ def test_enforce_spd_h_min(dim):
     h = 0.1
     metric = uniform_metric(mesh, a=1 / h**2)
     newmesh = try_adapt(mesh, metric)
-    num_vertices = newmesh.coordinates.vector().gather().shape[0]
+    num_vertices = newmesh.coordinates.dat.global_data.shape[0]
     metric.set_parameters({"dm_plex_metric_h_min": 0.2})  # h_min > h => h := h_min
     metric.enforce_spd(restrict_sizes=True)
     newmesh = try_adapt(mesh, metric)
-    assert newmesh.coordinates.vector().gather().shape[0] < num_vertices
+    assert newmesh.coordinates.dat.global_data.shape[0] < num_vertices
 
 
 @pytest.mark.parametrize("dim", [2, 3], ids=["mmg2d", "mmg3d"])
@@ -229,11 +235,11 @@ def test_enforce_spd_h_max(dim):
     h = 0.1
     metric = uniform_metric(mesh, a=1 / h**2)
     newmesh = try_adapt(mesh, metric)
-    num_vertices = newmesh.coordinates.vector().gather().shape[0]
+    num_vertices = newmesh.coordinates.dat.global_data.shape[0]
     metric.set_parameters({"dm_plex_metric_h_max": 0.05})  # h_max < h => h := h_max
     metric.enforce_spd(restrict_sizes=True)
     newmesh = try_adapt(mesh, metric)
-    assert newmesh.coordinates.vector().gather().shape[0] > num_vertices
+    assert newmesh.coordinates.dat.global_data.shape[0] > num_vertices
 
 
 # Debugging

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -198,8 +198,9 @@ def test_adapt_parallel_np2(dim, serialise):
 @pytest.mark.parallel(nprocs=3)
 @pytest.mark.parametrize(
     "dim,serialise",
-    [(2, True), (3, True)],  # [(2, True), (3, True), (3, False)], # FIXME: hang (#136)
-    ids=["mmg2d", "mmg3d"],  # ["mmg2d", "mmg3d", "ParMmg"],
+    # [(2, True), (3, True), (3, False)],  # FIXME: broken tests (#136, #197)
+    [(2, True)],
+    ids=["mmg2d"],  # ["mmg2d", "mmg3d", "ParMmg"],  # FIXME: broken tests (#136, #197)
 )
 def test_adapt_parallel_np3(dim, serialise):
     """
@@ -210,7 +211,13 @@ def test_adapt_parallel_np3(dim, serialise):
     test_adapt(dim, serialise=serialise)
 
 
-@pytest.mark.parametrize("dim", [2, 3], ids=["mmg2d", "mmg3d"])
+@pytest.mark.parametrize(
+    "dim",
+    # [2, 3],  # FIXME: Broken test (#197)
+    [2],
+    # ids=["mmg2d", "mmg3d"]  # FIXME: Broken test (#197)
+    ids=["mmg2d"],
+)
 def test_enforce_spd_h_min(dim):
     """
     Tests that :meth:`animate.metric.RiemannianMetric.enforce_spd` applies minimum
@@ -227,7 +234,13 @@ def test_enforce_spd_h_min(dim):
     assert newmesh.coordinates.dat.global_data.shape[0] < num_vertices
 
 
-@pytest.mark.parametrize("dim", [2, 3], ids=["mmg2d", "mmg3d"])
+@pytest.mark.parametrize(
+    "dim",
+    # [2, 3],  # FIXME: Broken test (#197)
+    [2],
+    # ids=["mmg2d", "mmg3d"]  # FIXME: Broken test (#197)
+    ids=["mmg2d"],
+)
 def test_enforce_spd_h_max(dim):
     """
     Tests that :meth:`animate.metric.RiemannianMetric.enforce_spd` applies maximum

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -182,8 +182,8 @@ def test_adapt(dim, serialise):
 @pytest.mark.parallel(nprocs=2)
 @pytest.mark.parametrize(
     "dim,serialise",
-    [(2, True), (3, True)],  # [(2, True), (3, True), (3, False)], # FIXME: hang (#136)
-    ids=["mmg2d", "mmg3d"],  # ["mmg2d", "mmg3d", "ParMmg"],
+    [(2, True)],  # [(2, True), (3, True), (3, False)],  # FIXME: broken (#136,#197)
+    ids=["mmg2d"],  # ["mmg2d", "mmg3d", "ParMmg"],  # FIXME: broken (#136,#197)
 )
 def test_adapt_parallel_np2(dim, serialise):
     """

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -707,7 +707,7 @@ class TestMetricDecompositions(MetricTestCase):
             for i in range(dim - 1):
                 f = Function(P1).interpolate(evalues[i])
                 f -= Function(P1).interpolate(evalues[i + 1])
-                if f.vector().gather().min() < 0.0:
+                if f.dat.global_data.min() < 0.0:
                     raise ValueError(
                         f"Eigenvalues are not in descending order: {evalues.dat.data}"
                     )

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -60,7 +60,7 @@ class TestQuality(unittest.TestCase):
         truth = Function(q.function_space()).assign(expected)
         self.assertAlmostEqual(errornorm(truth, q), 0.0, places=6)
         if measure == "area":
-            s = q.vector().gather().sum()
+            s = q.dat.global_data.sum()
             self.assertAlmostEqual(s, 1.0)
 
     @parameterized.expand(
@@ -79,7 +79,7 @@ class TestQuality(unittest.TestCase):
         truth = Function(q.function_space()).assign(expected)
         self.assertAlmostEqual(errornorm(truth, q), 0.0)
         if measure == "volume":
-            s = q.vector().gather().sum()
+            s = q.dat.global_data.sum()
             self.assertAlmostEqual(s, 1.0)
 
     @parameterized.expand(


### PR DESCRIPTION
Closes #200.

This PR replaces all uses of `Function.vector().gather()` with `.dat.global_data` to adopt new API.

It also drops use of `MeshGeometry.init()`, which no longer exists.

This PR also temporarily turns off other broken 3D tests reported in #197.