### PR TITLE
Avoid use of .vector().gather()

### DIFF
--- a/animate/recovery.py
+++ b/animate/recovery.py
@@ -13,6 +13,7 @@ from pyop2 import op2
 from .interpolation import clement_interpolant
 from .math import construct_basis
 from .quality import QualityMeasure, include_dir
+from .utility import function_data_max
 
 __all__ = ["recover_gradient_l2", "recover_hessian_clement", "recover_boundary_hessian"]
 
@@ -152,7 +153,7 @@ def recover_boundary_hessian(f, method="Clement", target_space=None, **kwargs):
     h = firedrake.assemble(
         interpolate(ufl.CellDiameter(mesh), firedrake.FunctionSpace(mesh, "DG", 0))
     )
-    h = firedrake.Constant(1 / h.vector().gather().max() ** 2)
+    h = firedrake.Constant(1 / function_data_max(h) ** 2)
     sp = {
         "ksp_type": "gmres",
         "ksp_gmres_restart": 20,

--- a/animate/utility.py
+++ b/animate/utility.py
@@ -10,8 +10,10 @@ import firedrake.mesh as fmesh
 import ufl
 from firedrake.__future__ import interpolate
 from firedrake.petsc import PETSc
+from mpi4py import MPI
 
-__all__ = ["Mesh", "VTKFile", "norm", "errornorm"]
+__all__ = ["Mesh", "VTKFile", "norm", "errornorm",
+           "function_data_min", "function_data_max", "function_data_sum"]
 
 
 @PETSc.Log.EventDecorator()
@@ -309,3 +311,21 @@ def function2cofunction(func):
     else:
         cofunc.dat.data_with_halos[:] = func.dat.data_with_halos
     return cofunc
+
+
+def function_data_min(f):
+    """Compute node-wise global minimum of Firedrake function"""
+    mesh = ufl.domain.extract_unique_domain(f)
+    return mesh.comm.allreduce(f.dat.data_ro.min(), MPI.MIN)
+
+
+def function_data_max(f):
+    """Compute node-wise global maximum of Firedrake function"""
+    mesh = ufl.domain.extract_unique_domain(f)
+    return mesh.comm.allreduce(f.dat.data_ro.max(), MPI.MAX)
+
+
+def function_data_sum(f):
+    """Compute global sum of nodal values of Firedrake function"""
+    mesh = ufl.domain.extract_unique_domain(f)
+    return mesh.comm.allreduce(f.dat.data_ro.sum(), MPI.SUM)

--- a/demos/ping_pong.py
+++ b/demos/ping_pong.py
@@ -64,8 +64,8 @@ plt.savefig("ping_pong-source_function.jpg", bbox_inches="tight")
 
 niter = 50
 initial_integral = assemble(source * dx)
-initial_min = source.vector().gather().min()
-initial_max = source.vector().gather().max()
+initial_min = function_data_min(source)
+initial_max = function_data_max(source)
 quantities = {
     "integral": {"interpolate": [initial_integral]},
     "minimum": {"interpolate": [initial_min]},
@@ -77,8 +77,8 @@ for _ in range(niter):
     interpolate(f_interp, tmp)
     interpolate(tmp, f_interp)
     quantities["integral"]["interpolate"].append(assemble(f_interp * dx))
-    quantities["minimum"]["interpolate"].append(f_interp.vector().gather().min())
-    quantities["maximum"]["interpolate"].append(f_interp.vector().gather().max())
+    quantities["minimum"]["interpolate"].append(function_data_min(f_interp))
+    quantities["maximum"]["interpolate"].append(function_data_max(f_interp))
 f_interp.rename("Interpolate")
 
 fig, axes = plt.subplots(ncols=3, figsize=(18, 5))
@@ -139,8 +139,8 @@ for _ in range(niter):
     project(f_proj, tmp)
     project(tmp, f_proj)
     quantities["integral"]["project"].append(assemble(f_proj * dx))
-    quantities["minimum"]["project"].append(f_proj.vector().gather().min())
-    quantities["maximum"]["project"].append(f_proj.vector().gather().max())
+    quantities["minimum"]["project"].append(function_data_min(f_proj))
+    quantities["maximum"]["project"].append(function_data_max(f_proj))
 f_proj.rename("Project")
 
 fig, axes = plt.subplots(ncols=3, figsize=(18, 5))
@@ -189,8 +189,8 @@ for _ in range(niter):
     project(f_bounded, tmp, bounded=True)
     project(tmp, f_bounded, bounded=True)
     quantities["integral"]["bounded"].append(assemble(f_bounded * dx))
-    quantities["minimum"]["bounded"].append(f_bounded.vector().gather().min())
-    quantities["maximum"]["bounded"].append(f_bounded.vector().gather().max())
+    quantities["minimum"]["bounded"].append(function_data_min(f_bounded))
+    quantities["maximum"]["bounded"].append(function_data_max(f_bounded))
 f_bounded.rename("Bounded project")
 
 fig, axes = plt.subplots(ncols=3, figsize=(18, 5))

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -16,6 +16,7 @@ from sensors import bowl, hyperbolic, interweaved, multiscale
 from test_setup import uniform_mesh, uniform_metric
 
 from animate.metric import P0Metric, RiemannianMetric
+from animate.utility import function_data_min
 
 
 class MetricTestCase(unittest.TestCase):
@@ -707,7 +708,7 @@ class TestMetricDecompositions(MetricTestCase):
             for i in range(dim - 1):
                 f = Function(P1).interpolate(evalues[i])
                 f -= Function(P1).interpolate(evalues[i + 1])
-                if f.vector().gather().min() < 0.0:
+                if function_data_min(f) < 0.0:
                     raise ValueError(
                         f"Eigenvalues are not in descending order: {evalues.dat.data}"
                     )

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -10,6 +10,7 @@ from parameterized import parameterized
 from test_setup import uniform_mesh
 
 from animate.quality import QualityMeasure
+from animate.utility import function_data_sum
 
 
 @pytest.fixture(params=[2, 3])
@@ -60,7 +61,7 @@ class TestQuality(unittest.TestCase):
         truth = Function(q.function_space()).assign(expected)
         self.assertAlmostEqual(errornorm(truth, q), 0.0, places=6)
         if measure == "area":
-            s = q.vector().gather().sum()
+            s = function_data_sum(q)
             self.assertAlmostEqual(s, 1.0)
 
     @parameterized.expand(
@@ -79,7 +80,7 @@ class TestQuality(unittest.TestCase):
         truth = Function(q.function_space()).assign(expected)
         self.assertAlmostEqual(errornorm(truth, q), 0.0)
         if measure == "volume":
-            s = q.vector().gather().sum()
+            s = function_data_sum(q)
             self.assertAlmostEqual(s, 1.0)
 
     @parameterized.expand(


### PR DESCRIPTION
Closes #200

Alternative for #201.
Removes usage of .vector()
Taking this opportunity to also eliminate .vector().gather() (which now would be .dat.global_data) as all-to-all gathers of function data should generally be avoided. All places where this was used were actually doing a reduction operation straight after, so now replaced
 with just an MPI allreduce. Introducing utility functions
function_data_min/max/sum for this as it gets a little wieldy.

Copies the other parts of #201:
It also drops use of MeshGeometry.init(), which no longer exists.

This PR also temporarily turns off other broken 3D tests reported in #197.

<!--
If your PR resolves one or more issues, please mention so here using "Closes #ISSUE_NUMBER", for each issue. This will hook things up so that those issues are automatically closed when the PR is merged.

If your PR is related to (but does not fully fix) one or more issues, please mention so here using "Related to #ISSUE_NUMBER" or "Towards #ISSUE_NUMBER", for each issue.

Please provide a summary of the changes made in this PR.

If you are adding new functionality then please add new tests to check things are working properly. (See the [Testing](https://github.com/mesh-adaptation/docs/wiki/Development-Practices#testing) wiki section for more details.)

Thanks for contributing!
-->
