### PR TITLE
Include cxx files in installed Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ Repository = "https://github.com/mesh-adaptation/animate"
 [tool.setuptools]
 packages = ["animate"]
 
+[tool.setuptools.package-data]
+animate = ["cxx/*.cxx"]
+
 [tool.ruff]
 line-length = 88
 


### PR DESCRIPTION
Maybe this is naive of me, but this should enable non-editable installs to succeed as well?