### PR TITLE
Update deprecated license spec in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0.3"]
 
 [project]
 name = "animate"


### PR DESCRIPTION
Closes #216

Can do the same for other packages, if you're happy with this...

Setuptools requirement (https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files)
is the same as firedrake main, so shouldn't be an issue