### PR TITLE
Introduce separate requirements-build.txt

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,11 @@
+# Build requirements needed to build cython module.
+# Note that we assume we are in a valid Firedrake
+# environment that have firedrake and petsc4py installed
+# already - we do not specify these here as they may
+# cause the locally installed ones to be replaced by the 
+# latest release from PyPI
+Cython
+numpy
+petsctools
+setuptools>=77.0.3
+wheel


### PR DESCRIPTION
Addresses #240 

This is needed because we are instructing our users to build with `pip install --no-build-isolation` which tells pip to build in the current python env and ignores the build dependencies specified in pyproject.toml. Following the installation instructions for Firedrake release however, this environment may not have these build requirements installed already (notably Cython and a sufficiently new setuptools). Therefore we need to instruct users to run `pip install -r animate/requirements-build.txt` beforehand.

TODO (after merge):
* update wiki installation instructions
* use the additional step in the CI