### PR TITLE
Introduce separate requirements-build.txt

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,11 @@
+# Build requirements needed to build cython module.
+# Note that we assume we are in a valid Firedrake
+# environment that have firedrake and petsc4py installed
+# already - we do not specify these here as they may
+# cause the locally installed ones to be replaced by the 
+# latest release from PyPI
+Cython
+numpy
+petsctools
+setuptools>=77.0.3
+wheel


### PR DESCRIPTION
Same as #241, see description there

Doing this before merging main into release (see #239) because I first want to fix the building of the firedrake-parmmg:release container which needs the additional requirements-build.txt step. After adding the step in "docs", it should then build again, but the animate tests will fail, which I will then address in #239.

Note that this merge has cherry-picked the commit from #241, which is not normally what we want to do as we end up with the same commit twice after merging main into release but I will deal with that in #239.

