### PR TITLE
Fix workflows to deal with PRs to release

### DIFF
--- a/.github/workflows/test_suite_main.yml
+++ b/.github/workflows/test_suite_main.yml
@@ -5,21 +5,11 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '**.py'
-      - '**.cxx'
-      - '.github/workflows/test_suite_main.yml'
-      - '.gitmodules'
-      - 'pyproject.toml'
 
-  # Run test suite whenever commits are pushed to an open PR
+  # Run test suite whenever commits are pushed to an open PR targetting main
   pull_request:
-    paths:
-      - '**.py'
-      - '**.cxx'
-      - '.github/workflows/test_suite_main.yml'
-      - '.gitmodules'
-      - 'pyproject.toml'
+    branches:
+      - main
 
   # Run test suite every Sunday at 1AM
   schedule:

--- a/.github/workflows/test_suite_release.yml
+++ b/.github/workflows/test_suite_release.yml
@@ -5,13 +5,11 @@ on:
   push:
     branches:
       - release
-    paths:
-      - '.github/workflows/test_suite_release.yml'
 
-  # Run test suite whenever commits that change this workflow are pushed to an open PR
+  # Run test suite whenever commits are pushed to an open PR targetting release
   pull_request:
-    paths:
-      - '.github/workflows/test_suite_release.yml'
+    branches:
+      - release
 
   # Run test suite at 3AM on the first of the month
   schedule:


### PR DESCRIPTION
Current test_suite_main triggers on every PR and runs the *main* test suite on the PR branch even when the PR targets release.

When a PR targets release it should run the PR branch in the release CI workflow (i.e. test it against firedrake release). Also after the merge into release (or any other change to release), we should run the *release* workflow on it to check everything is still solid.

I've also removed the path filters because I think they are a bit unsafe, it's very easy to overlook a file that might influence the correct running of the tests - and since the documentation lives elsewhere I think there are very few commits that do not need to be tested.

<!--
If your PR resolves one or more issues, please mention so here using "Closes #ISSUE_NUMBER", for each issue. This will hook things up so that those issues are automatically closed when the PR is merged.

If your PR is related to (but does not fully fix) one or more issues, please mention so here using "Related to #ISSUE_NUMBER" or "Towards #ISSUE_NUMBER", for each issue.

Please provide a summary of the changes made in this PR.

If you are adding new functionality then please add new tests to check things are working properly. (See the [Testing](https://github.com/mesh-adaptation/docs/wiki/Development-Practices#testing) wiki section for more details.)

Thanks for contributing!
-->
